### PR TITLE
Support "embedded" PR creation with gh

### DIFF
--- a/autoload/lilium/pr.vim
+++ b/autoload/lilium/pr.vim
@@ -1,5 +1,11 @@
 func! lilium#pr#Create(...) " {{{
-    let args = extend(['gh', 'pr', 'create'], a:000)
+    let extra = []
+    if a:0 == 1 && type(a:1) == type(extra)
+        let extra = a:1
+    else
+        let extra = a:000
+    endif
+    let args = extend(['gh', 'pr', 'create'], extra)
     call lilium#util#editor#Run(args, {
         \ 'enhanced': 1,
         \ })

--- a/autoload/lilium/pr.vim
+++ b/autoload/lilium/pr.vim
@@ -1,0 +1,6 @@
+func! lilium#pr#Create(...) " {{{
+    let args = extend(['gh', 'pr', 'create'], a:000)
+    call lilium#util#editor#Run(args, {
+        \ 'enhanced': 1,
+        \ })
+endfunc " }}}

--- a/autoload/lilium/strategy/gh/curl.vim
+++ b/autoload/lilium/strategy/gh/curl.vim
@@ -2,19 +2,19 @@
 " `curl`-based github strategy
 "
 
-func! s:curl(path)
-    let token = lilium#strategy#gh#hub#config#ReadToken()
+func! s:curl(state, path)
+    let token = lilium#strategy#gh#hub#config#ReadToken(a:state)
     let curl = 'curl --silent -H "Authorization: token ' . token . '" '
     return curl . 'https://api.github.com' . a:path
 endfunc
 
-func! s:curlRepo(path)
-    let repo = lilium#strategy#gh#hub#config#GetRepoPath()
-    return s:curl('/repos/' . repo . a:path)
+func! s:curlRepo(state, path)
+    let repo = lilium#strategy#gh#hub#config#GetRepoPath(a:state)
+    return s:curl(a:state, '/repos/' . repo . a:path)
 endfunc
 
 func! lilium#strategy#gh#curl#_repo(path)
-    return s:curlRepo(a:path)
+    return s:curlRepo({}, a:path)
 endfunc
 
 func! lilium#strategy#gh#curl#create()
@@ -23,32 +23,33 @@ func! lilium#strategy#gh#curl#create()
         return 0
     endif
 
+    let s = {}
+
     " NOTE: we currently only pull the token from the hub config
-    let token = lilium#strategy#gh#hub#config#ReadToken()
+    let token = lilium#strategy#gh#hub#config#ReadToken(s)
     if token ==# ''
         return 0
     endif
 
-    let s = {}
     func! s.exists() dict
         return self.repo() !=# ''
     endfunc
 
     func! s.repo() dict
-        return lilium#strategy#gh#hub#config#GetRepoPath()
+        return lilium#strategy#gh#hub#config#GetRepoPath(self)
     endfunc
 
     func! s.repoUrl() dict
-        return lilium#strategy#gh#hub#config#GetRepoUrl()
+        return lilium#strategy#gh#hub#config#GetRepoUrl(self)
     endfunc
 
     func! s.usersAsync(Callback) dict
-        let curl = s:curlRepo('/contributors')
+        let curl = s:curlRepo(self, '/contributors')
         call lilium#job#StartJson(curl, function(a:Callback, ['@gh']))
     endfunc
 
     func! s.issuesAsync(Callback) dict
-        let curl = s:curlRepo('/issues')
+        let curl = s:curlRepo(self, '/issues')
         call lilium#job#StartJson(curl, function(a:Callback, ['@gh']))
     endfunc
 

--- a/autoload/lilium/strategy/gh/hub.vim
+++ b/autoload/lilium/strategy/gh/hub.vim
@@ -26,11 +26,11 @@ func! lilium#strategy#gh#hub#create()
     endfunc
 
     func! s.repo() dict
-        return lilium#strategy#gh#hub#config#GetRepoPath()
+        return lilium#strategy#gh#hub#config#GetRepoPath(self)
     endfunc
 
     func! s.repoUrl() dict
-        return lilium#strategy#gh#hub#config#GetRepoUrl()
+        return lilium#strategy#gh#hub#config#GetRepoUrl(self)
     endfunc
 
     func! s.issuesAsync(Callback) dict

--- a/autoload/lilium/strategy/gh/hub/config.vim
+++ b/autoload/lilium/strategy/gh/hub/config.vim
@@ -8,8 +8,8 @@ func! lilium#strategy#gh#hub#config#Find() " {{
     return ''
 endfunc " }}}
 
-func! lilium#strategy#gh#hub#config#GetRepoUrl() " {{
-    let existing = get(b:, '_lilium_repo_url', '')
+func! lilium#strategy#gh#hub#config#GetRepoUrl(state) " {{
+    let existing = get(a:state, '_lilium_repo_url', '')
     if existing !=# ''
         return existing
     endif
@@ -23,12 +23,12 @@ func! lilium#strategy#gh#hub#config#GetRepoUrl() " {{
     endif
 
     let url = substitute(urlIssues, '/issues$', '', '')
-    let b:_lilium_repo_url = url
+    let a:state._lilium_repo_url = url
     return url
 endfunc " }}}
 
-func! lilium#strategy#gh#hub#config#GetRepoHost() " {{
-    let url = lilium#strategy#gh#hub#config#GetRepoUrl()
+func! lilium#strategy#gh#hub#config#GetRepoHost(state) " {{
+    let url = lilium#strategy#gh#hub#config#GetRepoUrl(a:state)
     if url ==# ''
         return ''
     endif
@@ -40,8 +40,8 @@ func! lilium#strategy#gh#hub#config#GetRepoHost() " {{
     return m[1]
 endfunc " }}}
 
-func! lilium#strategy#gh#hub#config#GetRepoPath() " {{
-    let url = lilium#strategy#gh#hub#config#GetRepoUrl()
+func! lilium#strategy#gh#hub#config#GetRepoPath(state) " {{
+    let url = lilium#strategy#gh#hub#config#GetRepoUrl(a:state)
     if url ==# ''
         return ''
     endif
@@ -73,8 +73,8 @@ func! lilium#strategy#gh#hub#config#ReadTokens() " {{
     return tokens
 endfunc " }}}
 
-func! lilium#strategy#gh#hub#config#ReadToken() " {{
-    let host = lilium#strategy#gh#hub#config#GetRepoHost()
+func! lilium#strategy#gh#hub#config#ReadToken(state) " {{
+    let host = lilium#strategy#gh#hub#config#GetRepoHost(a:state)
     if host ==# ''
         return ''
     endif

--- a/autoload/lilium/util/editor.vim
+++ b/autoload/lilium/util/editor.vim
@@ -1,0 +1,87 @@
+" TempScript borrowed from fugitive:
+if !exists('s:temp_scripts')
+  let s:temp_scripts = {}
+endif
+
+func! s:TempScript(...)
+    let body = join(a:000, "\n")
+    if !has_key(s:temp_scripts, body)
+        let temp = tempname() . '.vim'
+        call writefile(['#!/bin/sh'] + a:000, temp)
+        let s:temp_scripts[body] = temp
+    endif
+    return s:temp_scripts[body]
+endfunc
+
+func! s:RestoreTerm(state) " {{{
+    call writefile([], a:state.temp . '.exit')
+
+    exe a:state.windowSize .'split'
+    exe 'buffer ' . a:state.termBufnr
+    startinsert
+endfunc " }}}
+
+func! s:FinishEditing(editorBufnr, termBufnr) " {{{
+    augroup liliumEditor
+        autocmd!
+    augroup END
+
+    let state = getbufvar(a:termBufnr, 'lilium_editor_state')
+    let state.windowSize = winheight(bufwinnr(a:editorBufnr))
+    let state.termBufnr = a:termBufnr
+
+    " TODO can we actually avoid a flash caused by destroying
+    " the window? here, we basically just try to "restore"
+    " the window to the previous size...
+    call timer_start(10, { -> s:RestoreTerm(state) })
+endfunc " }}}
+
+func! lilium#util#editor#OnEdit(bufnr, args) " {{{
+    let [path] = a:args
+    let g:lilium_editing = path
+    let state = getbufvar(a:bufnr, 'lilium_editor_state')
+
+    setlocal bufhidden=hide
+
+    exe 'edit ' . path
+
+    if state.enhanced
+        call lilium#Enable()
+    endif
+
+    let editorBufnr = bufnr('%')
+
+    augroup liliumEditor
+        autocmd!
+        exe 'autocmd BufWinLeave <buffer> call <SID>FinishEditing(' . editorBufnr . ',' . a:bufnr . ')'
+    augroup END
+endfunc " }}}
+
+func! lilium#util#editor#Run(cmd, ...) " {{{
+    let config = a:0 ? a:1 : {}
+
+    let callback = ["call", "lilium#util#editor#OnEdit", ["$1"]]
+    let editor = 'sh ' . s:TempScript(
+          \ '[ -f "$LILIUM_TEMP.exit" ] && exit 1',
+          \ 'editing="$1"',
+          \ 'printf "\033]51;' . escape(json_encode(callback), '"') . '\007"',
+          \ 'while [ -f "$editing" -a ! -f "$LILIUM_TEMP.exit" ]; do sleep 0.05 2>/dev/null || sleep 1; done',
+          \ 'exit 0')
+
+    let state = extend(config, {
+        \ 'temp': tempname(),
+        \ })
+
+    let env = {
+        \ 'EDITOR': editor,
+        \ 'LILIUM_TEMP': state.temp,
+        \ }
+
+    let opts = {
+        \ 'env': env,
+        \ 'term_api': 'lilium#util#editor#',
+        \ }
+
+    let bufnr = term_start(a:cmd, opts)
+    call setbufvar(bufnr, 'lilium_editor_state', state)
+endfunc " }}}

--- a/autoload/lilium/util/editor.vim
+++ b/autoload/lilium/util/editor.vim
@@ -1,12 +1,16 @@
-" TempScript borrowed from fugitive: {{{
+" TempScript based on the same from fugitive: {{{
 if !exists('s:temp_scripts')
-  let s:temp_scripts = {}
+    let s:temp_scripts = {}
 endif
 
 func! s:TempScript(...)
     let body = join(a:000, "\n")
     if !has_key(s:temp_scripts, body)
-        let temp = tempname() . '.vim'
+        " the script name is visible in gh, so let's make it look like "vim"
+        let scriptDir = tempname()
+        call mkdir(scriptDir, 'p')
+        let temp = scriptDir . '/vim'
+
         call writefile(['#!/bin/sh'] + a:000, temp)
         let s:temp_scripts[body] = temp
     endif

--- a/autoload/lilium/util/editor.vim
+++ b/autoload/lilium/util/editor.vim
@@ -40,7 +40,7 @@ func! s:FinishEditing(editorBufnr, termBufnr) " {{{
     call timer_start(10, { -> s:RestoreTerm(state) })
 endfunc " }}}
 
-func! lilium#util#editor#OnEdit(bufnr, args) " {{{
+func! s:OnEdit(bufnr, args) " {{{
     let [path] = a:args
     let g:lilium_editing = path
     let state = getbufvar(a:bufnr, 'lilium_editor_state')
@@ -66,7 +66,9 @@ func! lilium#util#editor#Run(cmd, ...) " {{{
     let config = a:0 ? a:1 : {}
     let project = lilium#project()
 
-    let callback = ["call", "lilium#util#editor#OnEdit", ["$1"]]
+    let sid = expand('<SID>')
+
+    let callback = ["call",  sid . "OnEdit", ["$1"]]
     let editor = 'sh ' . s:TempScript(
           \ '[ -f "$LILIUM_TEMP.exit" ] && exit 1',
           \ 'editing="$1"',
@@ -84,11 +86,9 @@ func! lilium#util#editor#Run(cmd, ...) " {{{
         \ 'LILIUM_TEMP': state.temp,
         \ }
 
-    let opts = {
+    let bufnr = term_start(a:cmd, {
         \ 'env': env,
-        \ 'term_api': 'lilium#util#editor#',
-        \ }
-
-    let bufnr = term_start(a:cmd, opts)
+        \ 'term_api': sid,
+        \ })
     call setbufvar(bufnr, 'lilium_editor_state', state)
 endfunc " }}}

--- a/autoload/lilium/util/editor.vim
+++ b/autoload/lilium/util/editor.vim
@@ -46,6 +46,7 @@ func! lilium#util#editor#OnEdit(bufnr, args) " {{{
     exe 'edit ' . path
 
     if state.enhanced
+        let b:_lilium_project = state.project
         call lilium#Enable()
     endif
 
@@ -59,6 +60,7 @@ endfunc " }}}
 
 func! lilium#util#editor#Run(cmd, ...) " {{{
     let config = a:0 ? a:1 : {}
+    let project = lilium#project()
 
     let callback = ["call", "lilium#util#editor#OnEdit", ["$1"]]
     let editor = 'sh ' . s:TempScript(
@@ -69,6 +71,7 @@ func! lilium#util#editor#Run(cmd, ...) " {{{
           \ 'exit 0')
 
     let state = extend(config, {
+        \ 'project': project,
         \ 'temp': tempname(),
         \ })
 

--- a/autoload/lilium/util/editor.vim
+++ b/autoload/lilium/util/editor.vim
@@ -1,4 +1,4 @@
-" TempScript borrowed from fugitive:
+" TempScript borrowed from fugitive: {{{
 if !exists('s:temp_scripts')
   let s:temp_scripts = {}
 endif
@@ -11,7 +11,7 @@ func! s:TempScript(...)
         let s:temp_scripts[body] = temp
     endif
     return s:temp_scripts[body]
-endfunc
+endfunc " }}}
 
 func! s:RestoreTerm(state) " {{{
     call writefile([], a:state.temp . '.exit')


### PR DESCRIPTION
This enables a fugitive-like PR body editing UX where we can edit the buffer directly within the main Vim process, instead of a vim nested within a term buffer. In addition, it allows us to provide auto-complete in this buffer like we do for commit message buffers in fugitive!
