### PR TITLE
lsp: Prefetch & cache "base" ticket results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +553,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dashmap",
+ "itertools",
  "reqwest",
  "ropey",
  "serde",

--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 async-trait = "0.1.80"
 clap = { version = "4.1.0", features = ["derive"] }
 dashmap = "5.5.3"
+itertools = "0.13.0"
 reqwest = "0.12.4"
 ropey = "1.6.1"
 serde = "1.0.203"

--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "0.1.80"
-clap = { version = "=4.1.0", features = ["derive"] }
+clap = { version = "4.1.0", features = ["derive"] }
 dashmap = "5.5.3"
 reqwest = "0.12.4"
 ropey = "1.6.1"

--- a/lsp/src/adapters/asana/api.rs
+++ b/lsp/src/adapters/asana/api.rs
@@ -6,7 +6,7 @@ use super::model::AsanaTasksResult;
 
 const API_BASE: &str = "https://app.asana.com/api/1.0";
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AsanaClient {
     client: Client,
 }

--- a/lsp/src/adapters/asana/mod.rs
+++ b/lsp/src/adapters/asana/mod.rs
@@ -14,7 +14,7 @@ const TASK_URL_BASE: &str = "https://app.asana.com/0/0";
 mod api;
 mod model;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AsanaAdapter {
     config: AsanaConfig,
     client: AsanaClient,

--- a/lsp/src/adapters/asana/model.rs
+++ b/lsp/src/adapters/asana/model.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct AsanaConfig {
     pub token: String,
     pub workspace: Option<String>,

--- a/lsp/src/adapters/cached.rs
+++ b/lsp/src/adapters/cached.rs
@@ -83,7 +83,7 @@ impl<T: Adapter + Sync> Adapter for CachedAdapter<T> {
         match (base, self.adapter.tickets(context).await) {
             (Some(base), Ok(results)) => {
                 let mut combined = [base, results].concat();
-                combined.dedup_by_key(|ticket| ticket.reference.clone());
+                combined.dedup_by(|a, b| a.reference == b.reference);
                 Ok(combined)
             }
             (Some(base), Err(_)) => Ok(base),

--- a/lsp/src/adapters/cached.rs
+++ b/lsp/src/adapters/cached.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+use tower_lsp::lsp_types::Position;
+
+use crate::completion::{CompletionContext, CompletionKind};
+
+use super::{Adapter, Ticket};
+
+#[derive(Debug)]
+pub struct CachedAdapter<T: Adapter + Sync> {
+    adapter: T,
+    cached_tickets: Arc<RwLock<Option<Vec<Ticket>>>>,
+}
+
+impl<T: Adapter + Sync + Clone> Clone for CachedAdapter<T> {
+    fn clone(&self) -> Self {
+        CachedAdapter {
+            adapter: self.adapter.clone(),
+            cached_tickets: self.cached_tickets.clone(),
+        }
+    }
+}
+
+impl<T: Adapter + Sync + Send + Clone + 'static> CachedAdapter<T> {
+    pub fn wrap_and_init(adapter: Option<T>) -> Option<Self> {
+        if let Some(wrapped) = Self::wrap(adapter) {
+            let mut cloned = wrapped.clone();
+            tokio::spawn(async move {
+                cloned.init().await;
+            });
+            Some(wrapped)
+        } else {
+            None
+        }
+    }
+}
+
+impl<T: Adapter + Sync> CachedAdapter<T> {
+    pub fn wrap(adapter: Option<T>) -> Option<Self> {
+        adapter.map(Self::new)
+    }
+
+    pub fn new(adapter: T) -> Self {
+        Self {
+            adapter,
+            cached_tickets: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub async fn init(&mut self) {
+        let context = CompletionContext {
+            kind: CompletionKind::Tickets,
+            text: "".to_string(),
+            prefix_start: Position {
+                line: 0,
+                character: 0,
+            },
+        };
+        if let Ok(tickets) = self.adapter.tickets(&context).await {
+            let mut mutex = self.cached_tickets.write().await;
+            *mutex = Some(tickets);
+        }
+    }
+}
+
+#[async_trait]
+impl<T: Adapter + Sync> Adapter for CachedAdapter<T> {
+    async fn tickets(
+        &self,
+        context: &CompletionContext,
+    ) -> Result<Vec<Ticket>, super::AdapterError> {
+        let base = self.cached_tickets.read().await.clone();
+        if context.text.is_empty() {
+            if let Some(base) = base {
+                // Skip querying again; there's no search filter, and we already
+                // have these results!
+                return Ok(base.clone());
+            }
+        }
+
+        match (base, self.adapter.tickets(context).await) {
+            (Some(base), Ok(results)) => {
+                let mut combined = [base, results].concat();
+                combined.dedup_by_key(|ticket| ticket.reference.clone());
+                Ok(combined)
+            }
+            (Some(base), Err(_)) => Ok(base),
+            (None, fresh_result) => fresh_result,
+        }
+    }
+}

--- a/lsp/src/adapters/github/cli.rs
+++ b/lsp/src/adapters/github/cli.rs
@@ -6,7 +6,7 @@ use crate::adapters::AdapterError;
 
 use super::model::{GithubIssuesSearchResults, GithubNameWithOwner};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GhCli {
     pub root: Option<String>,
 }

--- a/lsp/src/adapters/github/mod.rs
+++ b/lsp/src/adapters/github/mod.rs
@@ -9,7 +9,7 @@ use self::cli::GhCli;
 
 use super::{Adapter, AdapterError, AdapterParams, Ticket};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GithubAdapter {
     cli: GhCli,
     repo_name: Option<String>,

--- a/lsp/src/adapters/mod.rs
+++ b/lsp/src/adapters/mod.rs
@@ -9,10 +9,11 @@ use crate::{completion::CompletionContext, progress::ProgressReporter};
 use self::composite::CompositeAdapter;
 
 mod asana;
+mod cached;
 pub(crate) mod composite;
 mod github;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Ticket {
     pub id: String,
     pub reference: String,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-04-27"


### PR DESCRIPTION
This change brings latency parity with the legacy implementations, which essentially make a single request up front and only use that, and also solves an issue where (depending on the provider's search implementation) you could start typing to filter down to one of the initial results and, when pausing, lose that item from the results.

By caching the initial query-less results, we can ensure that at least *those* will always be available to filter down to. We could consider caching all intermediate results, but this has felt pretty good so far!

- **Add a cached adapter for preloaded results and ensuring consistency**
- **Explicitly specify the rust-toolchain to use**
- **Optimize ticket dedup with `dedup_by` so we don't have to clone**
- **Fix duplicates using itertools' unique_by**
